### PR TITLE
Train model with AdamW optimizer

### DIFF
--- a/llm/pretraining.py
+++ b/llm/pretraining.py
@@ -83,7 +83,7 @@ def train_model_simple(model, train_loader, val_loader,
     return train_losses, val_losses, track_tokens_seen
 
 
-def evaluate_model(model, train, val_loader, device, eval_iter):
+def evaluate_model(model, train_loader, val_loader, device, eval_iter):
     model.eval()
     with torch.no_grad():
         train_loss = calc_loss_loader(


### PR DESCRIPTION
Rename `train` parameter to `train_loader` in `evaluate_model` function signature.

This resolves a `NameError` where `train_loader` was used internally in `evaluate_model` but the function signature expected a parameter named `train`.

---
<a href="https://cursor.com/background-agent?bcId=bc-118dbd4f-1e5f-4c88-b868-74c402f5dd16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-118dbd4f-1e5f-4c88-b868-74c402f5dd16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

